### PR TITLE
Ds/headless interpreter

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+    // required for jest, see this issue: https://github.com/vercel/next.js/issues/52541
+    transpilePackages: ['ramda']
+}
 
 module.exports = nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@testing-library/react": "^14.1.2",
         "@types/jest": "^29.5.10",
         "@types/node": "^20",
+        "@types/ramda": "^0.30.0",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@types/uuid": "^9.0.7",
@@ -1955,6 +1956,15 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
+    },
+    "node_modules/@types/ramda": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.0.tgz",
+      "integrity": "sha512-DQtfqUbSB18iM9NHbQ++kVUDuBWHMr6T2FpW1XTiksYRGjq4WnNPZLt712OEHEBJs7aMyJ68Mf2kGMOP1srVVw==",
+      "dev": true,
+      "dependencies": {
+        "types-ramda": "^0.30.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "18.2.38",
@@ -7926,6 +7936,12 @@
         }
       }
     },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "dev": true
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -8039,6 +8055,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/types-ramda": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.0.tgz",
+      "integrity": "sha512-oVPw/KHB5M0Du0txTEKKM8xZOG9cZBRdCVXvwHYuNJUVkAiJ9oWyqkA+9Bj2gjMsHgkkhsYevobQBWs8I2/Xvw==",
+      "dev": true,
+      "dependencies": {
+        "ts-toolbelt": "^9.6.0"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@testing-library/react": "^14.1.2",
     "@types/jest": "^29.5.10",
     "@types/node": "^20",
+    "@types/ramda": "^0.30.0",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/uuid": "^9.0.7",

--- a/src/app/api/reasoning/Interpreter.v1.headless.test.ts
+++ b/src/app/api/reasoning/Interpreter.v1.headless.test.ts
@@ -1,0 +1,110 @@
+import { State } from 'xstate';
+
+import { headlessInterpreter } from '.';
+import { MachineEvent, Context, StateConfig, Task } from '.';
+import { ReasonDemoActionTypes } from '@/app/context/ReasoningDemoContext';
+
+describe('headlessInterpreter', () => {
+    const mockDispatch = jest.fn();
+
+    const mockTask: Task = {
+        description: 'Mock Task',
+        implementation: (context: Context, event?: MachineEvent) => {
+            context.status = 1;
+        },
+    };
+
+    const mockStates: StateConfig[] = [
+        {
+            id: 'initial',
+            transitions: [{ on: 'NEXT', target: 'nextState' }],
+        },
+        {
+            id: 'nextState',
+            type: 'final',
+        },
+    ];
+
+    const mockFunctions = new Map<string, Task>([
+        ['mockTask', mockTask],
+    ]);
+
+    beforeEach(() => {
+        mockDispatch.mockClear();
+    });
+
+    it('should initialize and transition states correctly', () => {
+        const { done, stop, send } = headlessInterpreter(mockStates, mockFunctions, mockDispatch);
+
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+        expect(mockDispatch).toHaveBeenCalledWith({
+            type: ReasonDemoActionTypes.SET_STATE,
+            value: expect.objectContaining({
+                currentState: expect.any(Object),
+                context: expect.objectContaining({
+                    requestId: 'test',
+                    status: 0,
+                    stack: [],
+                }),
+            }),
+        });
+
+        expect(done()).toBe(false);
+
+        // Simulate the transition
+        const currentState = mockDispatch.mock.calls[0][0].value.currentState;
+
+        send({ type: 'RESUME_EXECUTION' });
+
+        expect(mockDispatch).toHaveBeenCalledTimes(2);
+        expect(mockDispatch).toHaveBeenCalledWith({
+            type: ReasonDemoActionTypes.SET_STATE,
+            value: expect.objectContaining({
+                currentState: expect.any(Object),
+                context: expect.objectContaining({
+                    requestId: 'test',
+                    status: 1,
+                    stack: [],
+                }),
+            }),
+        });
+
+        expect(done()).toBe(true);
+
+        stop();
+    });
+
+    it('should hydrate from the serialized state', () => {
+        const { serialize, stop } = headlessInterpreter(mockStates, mockFunctions, mockDispatch);
+
+        const currentState = mockDispatch.mock.calls[0][0].value.currentState;
+        const serializedState = serialize(currentState);
+
+        stop();
+
+        const { done, serialize: serializeNew, stop: stopNew } = headlessInterpreter(
+            mockStates,
+            mockFunctions,
+            mockDispatch,
+            undefined,
+            State.create(JSON.parse(serializedState))
+        );
+
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+        expect(mockDispatch).toHaveBeenCalledWith({
+            type: ReasonDemoActionTypes.SET_STATE,
+            value: expect.objectContaining({
+                currentState: expect.any(Object),
+                context: expect.objectContaining({
+                    requestId: 'test',
+                    status: 1,
+                    stack: [],
+                }),
+            }),
+        });
+
+        expect(done()).toBe(true);
+
+        stopNew();
+    });
+});

--- a/src/app/api/reasoning/index.ts
+++ b/src/app/api/reasoning/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export { default as engineV1 } from "./engine.v1";
 export { default as programV1 } from "./programmer.v1";
+export { default as headlessInterpreter } from "./interpreter.v1.headless";

--- a/src/app/api/reasoning/interpreter.v1.headless.ts
+++ b/src/app/api/reasoning/interpreter.v1.headless.ts
@@ -2,7 +2,6 @@ import { StateMachine, interpret, State } from "xstate";
 
 import { programV1, MachineEvent, Context, StateConfig, Task } from ".";
 import { ActionType } from "@/app/utils";
-import { ReasonDemoActionTypes } from "@/app/context/ReasoningDemoContext";
 
 export default function headlessInterpreter(
     states: StateConfig[],
@@ -22,7 +21,7 @@ export default function headlessInterpreter(
     const instance = interpret(machine).onTransition((state) => {
         console.log(`onTransition called: machine: ${machine.id} state: ${state.value}`);
         dispatch({
-            type: ReasonDemoActionTypes.SET_STATE,
+            type: 'SET_STATE',
             value: {
                 currentState: state,
                 context: state.context,
@@ -33,16 +32,16 @@ export default function headlessInterpreter(
             instance.stop(); // Stop the interpreter when the final state is reached
         }
     });
-    // if state is defined the machine will hydrate from where it left off as defined by the supplied state
-    // for more an persisting state visit: https://xstate.js.org/docs/guides/states.html#persisting-state
-    instance.start(state);
     const done = () => {
         return instance?.getSnapshot().done;
     }
     const serialize = (state: State<Context, MachineEvent>) => JSON.stringify(state);
     const stop = () => instance.stop();
     const send = (event: MachineEvent) => instance.send(event);
+    // if state is defined the machine will hydrate from where it left off as defined by the supplied state
+    // for more an persisting state visit: https://xstate.js.org/docs/guides/states.html#persisting-state
+    const start = () => instance.start(state);
 
     // TODO define an actual interface and think about what to expose
-    return { done, serialize, stop, send };
+    return { done, serialize, stop, send, start };
 }

--- a/src/app/api/reasoning/interpreter.v1.headless.ts
+++ b/src/app/api/reasoning/interpreter.v1.headless.ts
@@ -37,10 +37,7 @@ export default function headlessInterpreter(
     // for more an persisting state visit: https://xstate.js.org/docs/guides/states.html#persisting-state
     instance.start(state);
     const done = () => {
-        if (instance?.initialized) {
-            return instance?.getSnapshot().done;
-        }
-        return false;
+        return instance?.getSnapshot().done;
     }
     const serialize = (state: State<Context, MachineEvent>) => JSON.stringify(state);
     const stop = () => instance.stop();

--- a/src/app/api/reasoning/interpreter.v1.headless.ts
+++ b/src/app/api/reasoning/interpreter.v1.headless.ts
@@ -1,0 +1,51 @@
+import { StateMachine, interpret, State } from "xstate";
+
+import { programV1, MachineEvent, Context, StateConfig, Task } from ".";
+import { ActionType } from "@/app/utils";
+import { ReasonDemoActionTypes } from "@/app/context/ReasoningDemoContext";
+
+export default function headlessInterpreter(
+    states: StateConfig[],
+    functions: Map<string, Task>,
+    // callback function to revieve notifications on state change
+    dispatch: (action: ActionType) => void,
+    context?: Context,
+    state?: State<Context, MachineEvent>) {
+    const result: StateMachine<Context, any, MachineEvent> = programV1(states, functions);
+    const initialContext = context || {
+        status: 0,
+        requestId: "test",
+        stack: [],
+    };
+    const machine = result.withContext(initialContext);
+
+    const instance = interpret(machine).onTransition((state) => {
+        console.log(`onTransition called: machine: ${machine.id} state: ${state.value}`);
+        dispatch({
+            type: ReasonDemoActionTypes.SET_STATE,
+            value: {
+                currentState: state,
+                context: state.context,
+            }
+        });
+        if (state.done) {
+            console.log("Final state reached, stopping the interpreter.");
+            instance.stop(); // Stop the interpreter when the final state is reached
+        }
+    });
+    // if state is defined the machine will hydrate from where it left off as defined by the supplied state
+    // for more an persisting state visit: https://xstate.js.org/docs/guides/states.html#persisting-state
+    instance.start(state);
+    const done = () => {
+        if (instance?.initialized) {
+            return instance?.getSnapshot().done;
+        }
+        return false;
+    }
+    const serialize = (state: State<Context, MachineEvent>) => JSON.stringify(state);
+    const stop = () => instance.stop();
+    const send = (event: MachineEvent) => instance.send(event);
+
+    // TODO define an actual interface and think about what to expose
+    return { done, serialize, stop, send };
+}

--- a/src/app/api/reasoning/programmer.v1.ts
+++ b/src/app/api/reasoning/programmer.v1.ts
@@ -35,10 +35,6 @@ function generateStateConfig(state: StateConfig, functionCatalog: Map<string, Ta
     let stateConfig: any = {
         entry: (context: Context, event: MachineEvent) => {
             console.log("Received Event:", event.type);
-            // ignore init events
-            if (event.type === 'xstate.init') {
-                return;
-            }
             context.stack?.push(state.id);
             // if the function is async, we ignore the promise as this is fire and forget.
             // it's up to the function to dispatch the CONTINUE event on the machine to capture results

--- a/src/app/pages/api/regie/context.ts
+++ b/src/app/pages/api/regie/context.ts
@@ -1,0 +1,203 @@
+import { Context, MachineEvent, Task, } from "@/app/api/reasoning";
+import { ActionType } from "@/app/utils";
+import { regieProgrammer, regieSolver, regieEvaluate } from "@/app/api/reasoning/prompts/";
+
+function getFunctionCatalog(dispatch: (action: ActionType) => void) {
+    return new Map<string, Task>([
+        [
+            "AcceptTOS",
+            {
+                description:
+                    "Required step that allows the user to accept or reject the terms of service",
+                implementation: (context: Context, event?: MachineEvent) => {
+                    console.log('AcceptTOS implementation called');
+                    const payload = {
+                        AcceptTOS: { accepted: true, acceptedOn: Date.now() },
+                    };
+                    dispatch({
+                        type: 'CONTINUE',
+                        payload,
+                    });
+                },
+                transitions: new Map<"CONTINUE" | "ERROR", (context: Context, event: MachineEvent) => boolean>([
+                    [
+                        "CONTINUE",
+                        // this is an example of a deterministic function that is invoked as part of evaluating transitions
+                        // it can do whatever you like and take into account the current state of the world found on the context
+                        // The results of the implementation function should be include included in the payload of the incoming event
+                        // in this case we verify the user accepted the TOS
+                        (context: Context, event: MachineEvent) => {
+                            console.log(`AcceptTOS transitions called: ${JSON.stringify(event)}`);
+                            return event.payload?.AcceptTOS?.accepted;
+                        }
+                    ]
+                ]),
+            },
+        ],
+        [
+            "AgeConfirmation",
+            {
+                description: "Required step that allows the user to confirm they are at least 18 years of age",
+                // this is an example of how you can render a component while the implementation function executes
+                implementation: (context: Context, event?: MachineEvent) => {
+                    console.log('AgeConfirmation implementation called');
+                    const payload = {
+                        AgeConfirmation: { confirmed: true, acceptedOn: Date.now() },
+                    };
+                    dispatch({
+                        type: 'CONTINUE',
+                        payload,
+                    });
+                },
+                transitions: new Map<"CONTINUE" | "ERROR", (context: Context, event: MachineEvent) => boolean>([
+                    [
+                        "CONTINUE",
+                        // this is an example of a deterministic function that is invoked as part of evaluating transitions
+                        // it can do whatever you like and take into account the current state of the world found on the context
+                        // The results of the implementation function should be include included in the payload of the incoming event
+                        // in this case we verify the user is at least 18
+                        (context: Context, event: MachineEvent) => event.payload?.AgeConfirmation?.confirmed
+                    ]
+                ]),
+            },
+        ],
+        [
+            "PartnerPlugins",
+            {
+                description:
+                    "Optional step allows the user to select partner plugins they can sign up for",
+                implementation: (context: Context, event?: MachineEvent) => {
+                    console.log('PartnerPlugins implementation called');
+                    dispatch({ type: 'CONTINUE' });
+                },
+            },
+        ],
+        [
+            "RegisterUser",
+            {
+                description:
+                    "Required step to collect the users personal information",
+                implementation: (context: Context, event?: MachineEvent) => {
+                    console.log('RegisterUser implementation called');
+                    dispatch({ type: 'CONTINUE' });
+                },
+            },
+        ],
+        [
+            "SelectPlan",
+            {
+                description:
+                    "Required step that allows the user to select the subscription tier they would like",
+                implementation: (context: Context, event?: MachineEvent) => {
+                    console.log('SelectPlan implementation called');
+                    dispatch({ type: 'CONTINUE' });
+                },
+            },
+        ],
+        [
+            "SpecialOffers",
+            {
+                description: "Optional step that allows the user to select the special offers they would like",
+                implementation: (context: Context, event?: MachineEvent) => {
+                    console.log('SpecialOffers implementation called');
+                    dispatch({ type: 'CONTINUE' });
+                },
+            },
+        ],
+        [
+            "UnsupportedQuestion",
+            {
+                description:
+                    "Default state to display for unsupported questions",
+                implementation: (context: Context, event?: MachineEvent) => {
+                    console.log('UnsupportedQuestion implementation called');
+                    dispatch({ type: 'CONTINUE' });
+                }
+            },
+        ],
+        [
+            "UnsafeQuestion",
+            {
+                description:
+                    "Default state to display for unsafe questions",
+                implementation: (context: Context, event?: MachineEvent) => {
+                    console.log('UnsafeQuestion implementation called');
+                    dispatch({ type: 'CONTINUE' });
+                },
+            },
+        ]
+    ]);
+}
+
+function getToolsCatalog() {
+    return new Map<string, { description: string }>([
+        [
+            "AcceptTOS",
+            {
+                description:
+                    "Required step that allows the user to accept or reject the terms of service",
+            },
+        ],
+        [
+            "AgeConfirmation",
+            {
+                description: "Required step that allows the user to confirm they are at least 18 years of age",
+            },
+        ],
+        [
+            "PartnerPlugins",
+            {
+                description:
+                    "Optional step allows the user to select partner plugins they can sign up for",
+            },
+        ],
+        [
+            "RegisterUser",
+            {
+                description:
+                    "Required step to collect the users personal information",
+            },
+        ],
+        [
+            "SelectPlan",
+            {
+                description:
+                    "Required step that allows the user to select the subscription tier they would like",
+            },
+        ],
+        [
+            "SpecialOffers",
+            {
+                description: "Optional step that allows the user to select the special offers they would like",
+            },
+        ],
+        [
+            "UnsupportedQuestion",
+            {
+                description: "Default state to display for unsupported questions",
+            },
+        ],
+        [
+            "UnsafeQuestion",
+            {
+                description: "Default state to display for unsafe questions",
+            },
+        ],
+    ]);
+}
+
+function getMetaData() {
+    return {
+        title: 'I am Regie, the AI powered user registration system.',
+        description: 'Tell  me any special requests you have in the registration process and I\'ll taylor your experience if possible.',
+    }
+}
+
+export {
+    regieProgrammer,
+    regieSolver,
+    regieEvaluate,
+    getFunctionCatalog as regieFunctionCatalog,
+    getToolsCatalog as regieToolsCatalog,
+    getMetaData as regieMetaData,
+}

--- a/src/app/pages/api/regie/route.ts
+++ b/src/app/pages/api/regie/route.ts
@@ -1,0 +1,76 @@
+import { type NextRequest } from 'next/server';
+import { headers } from 'next/headers'
+
+import {
+    regieProgrammer,
+    regieSolver,
+    regieEvaluate,
+    regieFunctionCatalog,
+    regieToolsCatalog,
+    regieMetaData,
+} from './context';
+import { headlessInterpreter } from '@/app/api/reasoning';
+import { engineV1 as engine } from "@/app/api/reasoning";
+
+type ActionType = {
+    type: string;
+    value?: Record<string, unknown>;
+};
+
+export async function GET(request: NextRequest) {
+    const searchParams = request.nextUrl.searchParams
+    const query = searchParams.get('query');
+
+    if (!query) {
+        return Response.json({ response: 'Bad Request' }, {
+            status: 400,
+        });
+    }
+
+    const dispatch = (action: ActionType) => {
+        console.log(`route dispatch callback called`);
+    };
+    const sendProxy = (action: ActionType) => {
+        send(action);
+    };
+    const functions = regieFunctionCatalog(sendProxy);
+    const toolsCatalog = regieToolsCatalog();
+
+    const solverSolution = await engine.solver.solve(query, regieSolver);
+    // generate the program
+    const result = await engine.programmer.program(solverSolution, JSON.stringify(Array.from(toolsCatalog.entries())), regieProgrammer);
+    const evaluationResult = await engine.evaluator.evaluate({ query: `${solverSolution}\n${result}`, states: result, tools: functions }, regieEvaluate)
+    if (!evaluationResult.correct) {
+        // TODO, use the revised solutions provided by the evaluator once that functionality has been added
+        throw evaluationResult.error || new Error('The provided solution failed evaluation');
+    }
+
+    const { done, start, send } = headlessInterpreter(result, functions, dispatch);
+
+    try {
+        console.log('calling start');
+        start();
+
+        let iterations = 0;
+        // this effectively acts as a timeout. Be sure to adjust if you have long running functions in your states!
+        const MAX_ITERATIONS = 30;
+        while (!done() && iterations < MAX_ITERATIONS) {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            console.log('awaiting results');
+            iterations++;
+        }
+
+        if (iterations >= MAX_ITERATIONS) {
+            console.warn('Exceeded maximum iterations while awaiting results.');
+        }
+
+        return Response.json({ response: query });
+    } catch (e) {
+        console.log((e as Error).message);
+        console.log((e as Error).stack);
+        return Response.json({ response: 'Internal Server Error' }, {
+            status: 500,
+        });
+    }
+
+}

--- a/src/app/utils/storeFactory.tsx
+++ b/src/app/utils/storeFactory.tsx
@@ -6,6 +6,7 @@ export const APP_CONTEXT_IDENTIFIER = Symbol.for("appContext");
 export type ActionType = {
   type: string;
   value?: Record<string, unknown>;
+  payload?: Record<string, unknown>;
 };
 
 export type AppContextType<T, A = undefined> = {


### PR DESCRIPTION
Add the headless interpreter and test. I included a sample route to show how you can create an agent or other headless use case. Also removed the check for `xstate.init` when calling implementation functions. 